### PR TITLE
Fix pdf.js include to restore pdfjsLib global

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,12 @@
   <!-- Tesseract.js para OCR -->
   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5.0.3/dist/tesseract.min.js"></script>
   <!-- pdf.js para renderizar PDFs em canvas e extrair imagens para o OCR -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.6.82/pdf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script>
     // Config do pdf.js (worker)
-    pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.6.82/pdf.worker.min.js";
+    if (window.pdfjsLib) {
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js";
+    }
   </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load a pdf.js build that exposes the global `pdfjsLib`
- guard worker configuration so it only runs when the library is available

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68deaaabb898832a829c6523f4089897