### PR TITLE
Fix pdf.js loading errors and add favicon

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,6 +67,10 @@ async function tryExtractTextFromPdf(page) {
 }
 
 async function textFromPdf(file) {
+  const pdfjsLib = window.pdfjsLib;
+  if (!pdfjsLib) {
+    throw new Error("Biblioteca pdf.js não carregada");
+  }
   const arrayBuffer = await file.arrayBuffer();
   const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
   let fullText = "";
@@ -198,13 +202,18 @@ inpPdf.addEventListener("change", async (ev) => {
   const file = ev.target.files?.[0];
   if (!file) return;
   saveMsg.textContent = "Lendo PDF e extraindo texto...";
-  const { text, usouOcr } = await textFromPdf(file);
-  ocrTextFinal = text;
-  ocrDump.textContent = text;
-  preencherCampos(text);
-  saveMsg.textContent = usouOcr
-    ? "PDF processado com OCR. Revise e salve."
-    : "PDF processado. Revise e salve.";
+  try {
+    const { text, usouOcr } = await textFromPdf(file);
+    ocrTextFinal = text;
+    ocrDump.textContent = text;
+    preencherCampos(text);
+    saveMsg.textContent = usouOcr
+      ? "PDF processado com OCR. Revise e salve."
+      : "PDF processado. Revise e salve.";
+  } catch (err) {
+    console.error("Erro ao processar PDF", err);
+    saveMsg.innerHTML = `<span class="badge no">Falha ao ler o PDF.</span>`;
+  }
 });
 
 btnProcessarTexto.addEventListener("click", () => {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Controle de Vendas VTS — Etiquetas & Devoluções</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='28' height='28' x='2' y='2' rx='6' ry='6' fill='%23f97316'/%3E%3Ctext x='16' y='22' font-size='16' text-anchor='middle' fill='white'%3E📦%3C/text%3E%3C/svg%3E" />
   <!-- Firebase v10 modular -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.1/firebase-app.js";


### PR DESCRIPTION
## Summary
- access the pdf.js API through the global window object and surface a helpful error when it is unavailable
- wrap the PDF processing flow in a try/catch so the UI shows a failure badge instead of crashing
- embed a simple inline favicon to avoid the missing icon request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deace4d6e8832a9d8be4c40369de02