### PR TITLE
Force Firestore long polling fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
 
       db = initializeFirestore(app, {
         experimentalAutoDetectLongPolling: true,
+        experimentalForceLongPolling: true,
         useFetchStreams: false,
         localCache,
       });
@@ -62,6 +63,7 @@
       try {
         db = initializeFirestore(app, {
           experimentalAutoDetectLongPolling: true,
+          experimentalForceLongPolling: true,
           useFetchStreams: false,
           localCache: memoryLocalCache(),
         });


### PR DESCRIPTION
## Summary
- force Firestore to use long polling when the WebChannel transport is blocked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb115b4a4832ab7885f97b83ca618