### PR TITLE
Fix Firestore initialization flag conflict

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,6 @@
 
       db = initializeFirestore(app, {
         experimentalAutoDetectLongPolling: true,
-        experimentalForceLongPolling: true,
         useFetchStreams: false,
         localCache,
       });
@@ -63,7 +62,6 @@
       try {
         db = initializeFirestore(app, {
           experimentalAutoDetectLongPolling: true,
-          experimentalForceLongPolling: true,
           useFetchStreams: false,
           localCache: memoryLocalCache(),
         });


### PR DESCRIPTION
## Summary
- remove experimentalForceLongPolling from Firestore initialization to avoid conflict with auto-detect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb2c7cd54832a9324ed7654a8f0ff