### PR TITLE
Fix Firebase storage bucket configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       apiKey: "AIzaSyDWok2hM9-HWITlLuqmYhGgEx8giXRUSTA",
       authDomain: "vtscontrole.firebaseapp.com",
       projectId: "vtscontrole",
-      storageBucket: "vtscontrole.firebasestorage.app",
+      storageBucket: "vtscontrole.appspot.com",
       messagingSenderId: "538434942205",
       appId: "1:538434942205:web:c174a1e336e5b75628fa94"
     };


### PR DESCRIPTION
## Summary
- correct the Firebase configuration to use the default appspot.com storage bucket domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb3c3c7ac832a9705a49ef77939b5